### PR TITLE
Array.isArray is not available on older versions of JavaScript

### DIFF
--- a/lib/nowUtil.js
+++ b/lib/nowUtil.js
@@ -74,8 +74,8 @@ nowUtil.initializeScope = function(obj, socket) {
   socket.send({type: 'createScope', data: {scope: scope}});
 }
 
-nowUtil.isArray = function (obj) {
-  return Array.isArray(obj);
+nowUtil.isArray = Array.isArray || function (obj) {
+  return  Object.prototype.toString.call(obj) === '[object Array]'; 
 }
 
 nowUtil.getVarFromFqn = function(fqn, scope){


### PR DESCRIPTION
It specifically caused issues with Firefox version 3.6.15 (Ubuntu Linux). The fix is a suggestion provided at the Mozilla Developer Center: http://mzl.la/g8rwal.
