### PR TITLE
Custom host/port

### DIFF
--- a/lib/nowServerLib.js
+++ b/lib/nowServerLib.js
@@ -238,9 +238,6 @@ var serveFile = function(filename, request, response, options){
           }
 	    hostPort = options['port'] || hostPort;
 
-	    console.log(hostServer);
-	    console.log(hostPort);
-          
           var text = data.toString();
           text = text.replace(/\*\*SERVER\*\*/g, hostServer);
           text = text.replace(/\*\*PORT\*\*/g, hostPort);

--- a/lib/nowServerLib.js
+++ b/lib/nowServerLib.js
@@ -231,12 +231,15 @@ var serveFile = function(filename, request, response, options){
         fs.readFile(filename, function(err, data){  
 
           var host = request.headers.host.split(":");
-          var hostServer = host[0] || options['host'];
+          var hostServer = options['host'] || host[0];
           var hostPort = '80';
           if(host.length > 1){
             hostPort = host[1];
           }
-	  hostPort = hostPort || options['port'];
+	    hostPort = options['port'] || hostPort;
+
+	    console.log(hostServer);
+	    console.log(hostPort);
           
           var text = data.toString();
           text = text.replace(/\*\*SERVER\*\*/g, hostServer);

--- a/lib/nowServerLib.js
+++ b/lib/nowServerLib.js
@@ -218,7 +218,9 @@ var nowCore = {
   }
 };
 
-var serveFile = function(filename, request, response){
+var serveFile = function(filename, request, response, options){
+    var options = options || {};
+
   if(fileCache.hasOwnProperty(filename)) {
     response.writeHead(200);
     response.write(fileCache[filename]);
@@ -229,11 +231,12 @@ var serveFile = function(filename, request, response){
         fs.readFile(filename, function(err, data){  
 
           var host = request.headers.host.split(":");
-          var hostServer = host[0];
+          var hostServer = host[0] || options['host'];
           var hostPort = '80';
           if(host.length > 1){
             hostPort = host[1];
           }
+	  hostPort = hostPort || options['port'];
           
           var text = data.toString();
           text = text.replace(/\*\*SERVER\*\*/g, hostServer);
@@ -278,7 +281,8 @@ var handleNewConnection = function(client){
   });
 };
 
-exports.initialize = function(server){
+exports.initialize = function(server, options){
+  var options = options || {};
   // Override the default HTTP server listeners
   var defaultListeners = server.listeners('request');
   server.removeAllListeners('request');
@@ -287,7 +291,7 @@ exports.initialize = function(server){
     var i;
     if(request.method === "GET"){
       if(request.url.split('?')[0] === "/nowjs/now.js") {
-        serveFile(__dirname + '/now.js', request, response);
+          serveFile(__dirname + '/now.js', request, response, options);
       } else {
         for(i in defaultListeners){
           defaultListeners[i].call(server, request, response);


### PR DESCRIPTION
Hey,

I was having trouble using now.js when running node behind an nginx reverse_proxy. 

This little patch solves that problem by enabling users to pass a custom host/port combination to Now when initializing so it fills out /nowjs/now.js with the correct information instead of some bogus localhost and strange port configuration.

Cheers,
~Swizec
