### PR TITLE
Fixes double send issue

### DIFF
--- a/lib/nowServerLib.js
+++ b/lib/nowServerLib.js
@@ -153,14 +153,14 @@ var nowCore = {
 
   handleDisconnection: function(client) {
     //Remove scope and other functions
-    setTimeout(function(){
-      if(!client.connected) {
+    //setTimeout(function(){
+    //  if(!client.connected) {
         everyone.disconnected.apply({now: nowCore.scopes[client.sessionId], user:{clientId: client.sessionId} });
         delete nowCore.scopes[client.sessionId];
         delete nowCore.proxies[client.sessionId];
         delete nowCore.closures[client.sessionId];
-      }    
-    }, 2000);
+    //  }    
+    //}, 2000);
   },
 
   constructHandleFunctionForClientScope: function(client) {


### PR DESCRIPTION
When user refreshes the browser the disconnect and cleanup is not happening fast enough. Calling sendBroadcast right away will cause that user to receive the same message twice.
