### PR TITLE
don't send messages back to the author

### DIFF
--- a/examples/multiroomchat_example/multiroomchat.html
+++ b/examples/multiroomchat_example/multiroomchat.html
@@ -17,6 +17,7 @@ $(document).ready(function(){
     now.distributeMessage(message);
     $("#messages").append("<br>Me: " + message);
     $("#text-input").val("");
+    return false;
   });
   
   $(".change").click(function(){

--- a/examples/multiroomchat_example/multiroomchat.html
+++ b/examples/multiroomchat_example/multiroomchat.html
@@ -13,14 +13,15 @@ $(document).ready(function(){
   }
   
   $("#send-button").click(function(){
-    now.distributeMessage($("#text-input").val());
+    message = $("#text-input").val();
+    now.distributeMessage(message);
+    $("#messages").append("<br>Me: " + message);
     $("#text-input").val("");
   });
   
   $(".change").click(function(){
     now.changeRoom($(this).text());
   });
-  
 });
 </script>
 </head> 

--- a/examples/multiroomchat_example/multiroomchat.html
+++ b/examples/multiroomchat_example/multiroomchat.html
@@ -12,7 +12,7 @@ $(document).ready(function(){
     $("#messages").append("<br>" + name + ": " + message);
   }
   
-  $("#send-button").click(function(){
+  $("form").submit(function(){
     message = $("#text-input").val();
     now.distributeMessage(message);
     $("#messages").append("<br>Me: " + message);
@@ -35,7 +35,11 @@ $(document).ready(function(){
 </div>
 <br>
 <div id="messages"><br>You're in room 1</div>
-<input type="text" id="text-input">
-<input type="button" value="Send" id="send-button">
+    <form>
+        <p>
+            <input type="text" id="text-input">
+            <input type="button" value="Send" id="send-button">
+        </p>
+    </form>
 </body> 
 </html> 

--- a/examples/multiroomchat_example/multiroomchat.html
+++ b/examples/multiroomchat_example/multiroomchat.html
@@ -21,7 +21,7 @@ $(document).ready(function(){
   });
   
   $(".change").click(function(){
-    now.changeRoom($(this).text());
+    now.setRoom($(this).text());
   });
 });
 </script>

--- a/examples/multiroomchat_example/multiroomchat_server.js
+++ b/examples/multiroomchat_example/multiroomchat_server.js
@@ -12,40 +12,52 @@ server.listen(8080);
 var nowjs = require("now");
 var everyone = nowjs.initialize(server);
 
-
-everyone.on('connect', function(){
-  var defaultRoom = "room 1",
-      group = nowjs.getGroup(defaultRoom);
-
-  this.now.room = defaultRoom;
-
-  if (group.now.receiveMessage) {
-    group.now.receiveMessage("SERVER", this.now.name + " has joined the channel");
-  }
-  group.addUser(this.user.clientId);
-
+everyone.on('connect', function() {
+  this.now.setRoom("room 1");
   console.log("Joined: " + this.now.name);
 });
 
-
-everyone.on('disconnect', function(){
+everyone.on('disconnect', function() {
+  if (this.now.room) {
+    this.now.setRoom(false);
+  }
   console.log("Left: " + this.now.name);
 });
 
-everyone.now.changeRoom = function(newRoom){
-  var group = nowjs.getGroup(this.now.room);
+everyone.now.setRoom = function(newRoom) {
+  var group;
+ 
+  if (this.now.room) {
+    group = nowjs.getGroup(this.now.room);
+    group.removeUser(this.user.clientId);
+    group.now.receiveMessage("SERVER", this.now.name + " has left the room");
+  } 
+ 
+  if (newRoom) { 
+    this.now.room = newRoom;
   
-  group.removeUser(this.user.clientId);
-  group.now.receiveMessage("SERVER", this.now.name + " has left the room");
-
-  this.now.room = newRoom;
-  this.now.receiveMessage("SERVER", "You're now in " + this.now.room);
-
-  group = nowjs.getGroup(newRoom);
-  if (group.now.receiveMessage) {
-    group.now.receiveMessage("SERVER", this.now.name + " has joined the room");
-  }  
-  group.addUser(this.user.clientId);
+    group = nowjs.getGroup(newRoom);
+  
+    if (group.count) {
+        /* Best way to do this?
+        present = [];
+        group.now.each(function(member) {
+              present.push(member.now.name);
+        });
+        suffix = ". Users here: " + present.join(', ');
+        */
+        suffix = ". Other users present: " + group.count;
+    } else {
+        suffix = ". You're the only one here";
+    }
+  
+    this.now.receiveMessage("SERVER", "You're now in " + this.now.room + suffix) ;
+  
+    if (group.now.receiveMessage) {
+      group.now.receiveMessage("SERVER", this.now.name + " has joined the room");
+    }  
+    group.addUser(this.user.clientId);
+  }
 }
 
 everyone.now.distributeMessage = function(message){
@@ -57,4 +69,4 @@ everyone.now.filterMessage = function(clientId, name, message){
         return;
     }
     this.now.receiveMessage(name, message);
-}
+};

--- a/examples/multiroomchat_example/multiroomchat_server.js
+++ b/examples/multiroomchat_example/multiroomchat_server.js
@@ -19,8 +19,8 @@ everyone.on('connect', function(){
 
   this.now.room = defaultRoom;
 
-  if (group.distributeMessage) {
-    group.distributeMessage(this.now.name + " has joined the channel");
+  if (group.now.receiveMessage) {
+    group.now.receiveMessage("SERVER", this.now.name + " has joined the channel");
   }
   group.addUser(this.user.clientId);
 
@@ -33,10 +33,19 @@ everyone.on('disconnect', function(){
 });
 
 everyone.now.changeRoom = function(newRoom){
-  nowjs.getGroup(this.now.room).removeUser(this.user.clientId);
-  nowjs.getGroup(newRoom).addUser(this.user.clientId);
+  var group = nowjs.getGroup(this.now.room);
+  
+  group.removeUser(this.user.clientId);
+  group.now.receiveMessage("SERVER", this.now.name + " has left the room");
+
   this.now.room = newRoom;
   this.now.receiveMessage("SERVER", "You're now in " + this.now.room);
+
+  group = nowjs.getGroup(newRoom);
+  if (group.now.receiveMessage) {
+    group.now.receiveMessage("SERVER", this.now.name + " has joined the room");
+  }  
+  group.addUser(this.user.clientId);
 }
 
 everyone.now.distributeMessage = function(message){

--- a/examples/multiroomchat_example/multiroomchat_server.js
+++ b/examples/multiroomchat_example/multiroomchat_server.js
@@ -14,8 +14,16 @@ var everyone = nowjs.initialize(server);
 
 
 everyone.on('connect', function(){
-  this.now.room = "room 1";
-  nowjs.getGroup(this.now.room).addUser(this.user.clientId);
+  var defaultRoom = "room 1",
+      group = nowjs.getGroup(defaultRoom);
+
+  this.now.room = defaultRoom;
+
+  if (group.distributeMessage) {
+    group.distributeMessage(this.now.name + " has joined the channel");
+  }
+  group.addUser(this.user.clientId);
+
   console.log("Joined: " + this.now.name);
 });
 
@@ -32,5 +40,12 @@ everyone.now.changeRoom = function(newRoom){
 }
 
 everyone.now.distributeMessage = function(message){
-  nowjs.getGroup(this.now.room).now.receiveMessage(this.now.name, message);
+  nowjs.getGroup(this.now.room).now.filterMessage(this.user.clientId, this.now.name, message);
 };
+
+everyone.now.filterMessage = function(clientId, name, message){
+    if (clientId === this.user.clientId) {
+        return;
+    }
+    this.now.receiveMessage(name, message);
+}


### PR DESCRIPTION
It seems quite .. wrong that a message sent from a user needs to go to the server, and back before the author sees the message appear. This implies a lot more traffic than necessary, and also means the author does not see the result of their action immediately - they are delayed by the time it takes for the data to go to the server and back - which depending on their connection could be a noticable delay.

Rather than use the most simple case as before, these changes don't send message back to the author - they rely on the client side js for that and only send messages to /other/ users present in the appropriate room
