### PR TITLE
Caching for multiple domain port combinations for now.js generated script

### DIFF
--- a/lib/fileServer.js
+++ b/lib/fileServer.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 
 var fileCache = {};
-var nowFileCache;
+var nowFileCache = {};
 
 var defaultListeners;
 var server;
@@ -52,32 +52,32 @@ function serveFile(filename, request, response, options){
   } else {  
     if(filename.indexOf("/now.js") !== -1) {
       
-      // If not cached
-      if(nowFileCache === undefined) {
-        
+	  // Write file from cache if possible
+      if(nowFileCache.hasOwnProperty(request.headers.host)) {
+      
+        // Write file from cache
+        response.writeHead(200, {'content-type': 'text/javascript'});
+        response.write(nowFileCache[request.headers.host].nowUtil);
+        response.write(nowFileCache[request.headers.host].now);
+        response.end();
+      } else {
         // Determine hostname / port if not given in options
         var host = request.headers.host.split(":");
         var hostServer = options['host'] || host[0];
         var hostPort =  options['port'] || host[1] || '80';
         
         // Call generate client libs, which takes the desired host/port and executes callback with two parts of now.js as parameters
-        generateClientLibs(hostServer, hostPort, function(nowText, utilText){
-          
-          // Add to cache
-          nowFileCache = {now: nowText, nowUtil: utilText};
-          
+        generateClientLibs(hostServer, hostPort, function(nowText, utilText){          
+        
           // Write to client
           response.writeHead(200, {'content-type': 'text/javascript'});
-          response.write(nowFileCache.nowUtil);
-          response.write(nowFileCache.now);
+          response.write(utilText);
+          response.write(nowText);
           response.end();
+
+          // Add to cache
+          nowFileCache[request.headers.host] = {now: nowText, nowUtil: utilText};
         });
-      } else {
-        // Write file from cache
-        response.writeHead(200, {'content-type': 'text/javascript'});
-        response.write(nowFileCache.nowUtil);
-        response.write(nowFileCache.now);
-        response.end();
       }
     } else {
       // For any other filename, read file and server (not cached)


### PR DESCRIPTION
We're hosting from multiple domain names, and found an issue where the caching assumes that only one hostname/port combo will ever access now.js - fixed it.

switched nowFileCache from a simple object to an object keyed by [request.headers.host] to contain the now.js file for that specifc host.
