### PR TITLE
re-broadcast socket io events

### DIFF
--- a/lib/now.js
+++ b/lib/now.js
@@ -347,11 +347,11 @@ var nowLib = {
       nowCore.emit('disconnect');
     });
     // Forward planning for socket io 0.7
-    client.on('reconnect', function(){
-      nowCore.emit('reconnect');
-    });
     client.on('error', function(){
       nowCore.emit('error');
+    });
+    client.on('retry', function(){
+      nowCore.emit('retry');
     });
     client.on('reconnect', function(){
       nowCore.emit('reconnect');

--- a/lib/now.js
+++ b/lib/now.js
@@ -386,6 +386,19 @@ var now = {
       nowLib.handleNewConnection(client);
       nowCore.emit('connect');
     });
+    socket.on('disconnect', function(){
+      nowCore.emit('disconnect');
+    });
+    // Forward planning for socket io 0.7
+    socket.on('reconnect', function(){
+      nowCore.emit('reconnect');
+    });
+    socket.on('error', function(){
+      nowCore.emit('error');
+    });
+    socket.on('reconnect', function(){
+      nowCore.emit('reconnect');
+    });
   };
 
   for(var i=0, ii = dependencies.length; i < ii; i++){

--- a/lib/now.js
+++ b/lib/now.js
@@ -346,6 +346,16 @@ var nowLib = {
       nowCore.handleDisconnection(client);
       nowCore.emit('disconnect');
     });
+    // Forward planning for socket io 0.7
+    client.on('reconnect', function(){
+      nowCore.emit('reconnect');
+    });
+    client.on('error', function(){
+      nowCore.emit('error');
+    });
+    client.on('reconnect', function(){
+      nowCore.emit('reconnect');
+    });
   }
   
 };
@@ -385,19 +395,6 @@ var now = {
       now.core.clientId = socket.transport.sessionid;
       nowLib.handleNewConnection(client);
       nowCore.emit('connect');
-    });
-    socket.on('disconnect', function(){
-      nowCore.emit('disconnect');
-    });
-    // Forward planning for socket io 0.7
-    socket.on('reconnect', function(){
-      nowCore.emit('reconnect');
-    });
-    socket.on('error', function(){
-      nowCore.emit('error');
-    });
-    socket.on('reconnect', function(){
-      nowCore.emit('reconnect');
     });
   };
 


### PR DESCRIPTION
there are a number of socket.io events which if you use nowjs, you don't know about.

Added an emit for disconnect - and some future planning for events coming in socket io 0.7

PS. what's your whitespace code standard? not all files are without a new line at the end of the file.
