### PR TITLE
Allow for reduced http requests

### DIFF
--- a/lib/now.js
+++ b/lib/now.js
@@ -6,36 +6,36 @@ var nowCore = {
 
   // The client scope
   scopes: {},
-  
+
   // Watcher objects for all variables in client
   watchers: {},
-  
+
   // Blacklist of items to not trigger watcher callback for
   watchersBlacklist: {},
-  
-  
+
+
   // Contains references to closures passed in as pararmeters to remote calls
   // (Generated closure id) => reference to closure function
   closures: {},
 
-  
+
   // All of the different client messages we'll handle
   messageHandlers: {
-  
+
     // A remote function call from client
     remoteCall: function(client, data){
       nowUtil.debug("handleRemoteCall", data.callId);
       var clientScope = nowCore.scopes[client.sessionId];
-      
+
       var theFunction;
-      
+
       // Retrieve the function, either from closures hash or from the now scope
       if(data.fqn.split('_')[0] === 'closure'){
         theFunction = nowCore.closures[data.fqn];
       } else {
         theFunction = nowUtil.getVarFromFqn(data.fqn, clientScope);
       }
-      
+
       var theArgs = data.args;
 
       if(typeof theArgs === "object" && !nowUtil.isArray(theArgs)) {
@@ -46,97 +46,97 @@ var nowCore = {
         }
         theArgs = args;
       }
-      
+
       // Search (only at top level) of args for functions parameters, and replace with wrapper remote call function
       for(var i, ii = theArgs.length; i < ii; i++){
         if(nowUtil.hasProperty(theArgs[i], 'type') && theArgs[i].type === 'function'){
           theArgs[i] = nowCore.constructRemoteFunction(client, theArgs[i].fqn);
         }
       }
-      
+
       // Call the function with this.now and this.user
       theFunction.apply({now: clientScope, clientId: client.sessionId}, theArgs);
-     
+
       nowUtil.debug("handleRemoteCall" , "completed " + data.callId);
     },
 
-    
+
     // Called by initializeScope from the client side
     createScope: function(client, data){
-      
+
       // Initialize blacklist object
       nowCore.watchersBlacklist[client.sessionId] = {};
-      
+
       // This is the now object as populated by the client
       // constructHandleFunctionForClientScope returns a function that will generate multicallers and remote call functions for this client
       var scope = nowUtil.retrocycle(data.scope, nowCore.constructHandleFunctionForClientScope(client));
-      
+
       nowUtil.debug("handleCreateScope", "");
       nowUtil.print(scope);
-      
+
       // Blacklist the entire scope so it is not sent back to the client
       nowUtil.addChildrenToBlacklist(nowCore.watchersBlacklist[client.sessionId], scope, "now");
-      
-      
+
+
       // Create the watcher object
       nowCore.watchers[client.sessionId] = new nowLib.NowWatcher("now", scope, {}, function(prop, fqn, oldVal, newVal){
-        
+
         // Handle variable vale changes in this callback
-        
+
         // If not on blacklist do changes
         if(!nowUtil.hasProperty(nowCore.watchersBlacklist[client.sessionId], fqn)){
           nowUtil.debug("clientScopeWatcherVariableChanged", fqn + " => " + newVal);
           if(oldVal && typeof oldVal === "object") {
             var oldFqns = nowUtil.getAllChildFqns(oldVal, fqn);
-            
+
             for(var i in oldFqns) {
-              delete nowCore.watchers[client.sessionId].data.watchedKeys[oldFqns[i]];  
+              delete nowCore.watchers[client.sessionId].data.watchedKeys[oldFqns[i]];
             }
           }
-          
-          
+
+
           nowUtil.addChildrenToBlacklist(nowCore.watchersBlacklist[client.sessionId], newVal, fqn);
-          
+
           var key = fqn.split(".")[1];
           var data = nowUtil.decycle(scope[key], "now."+key, [nowUtil.serializeFunction]);
-          
-          client.send({type: 'replaceVar', data: {key: key, value: data[0]}});    
+
+          client.send({type: 'replaceVar', data: {key: key, value: data[0]}});
         } else {
           // If on blacklist, remove from blacklist
           nowUtil.debug("clientScopeWatcherVariableChanged", fqn + " change ignored");
           delete nowCore.watchersBlacklist[client.sessionId][fqn];
         }
-        
+
         // In case the object is an array, we delete from hashedArrays to prevent multiple watcher firing
         delete nowCore.watchers[client.sessionId].data.hashedArrays[fqn];
-        
+
       });
-      
-      
+
+
       nowCore.scopes[client.sessionId] = scope;
       nowLib.nowJSReady();
     },
 
     replaceVar: function(client, data){
       nowUtil.debug("handleReplaceVar", data.key + " => " + data.value);
-      
-      var scope = nowCore.scopes[client.sessionId];     
+
+      var scope = nowCore.scopes[client.sessionId];
       var newVal = nowUtil.retrocycle(data.value, nowCore.constructHandleFunctionForClientScope(client));
 
       nowCore.watchersBlacklist[client.sessionId]["now."+data.key] = true;
       nowUtil.addChildrenToBlacklist(nowCore.watchersBlacklist[client.sessionId], newVal, "now."+data.key);
-      
+
       for(var key in nowCore.watchers[client.sessionId].data.watchedKeys) {
         if(key.indexOf("now."+data.key+".") === 0) {
           delete nowCore.watchers[client.sessionId].data.watchedKeys[key];
         }
       }
-      
+
       if(nowUtil.hasProperty(data.value, "type") && data.value.type === 'function') {
         data.value = nowCore.constructRemoteFunction(client, data.value.fqn);
         newVal = data.value;
       }
-      
+
       scope[data.key] = newVal;
     }
   },
@@ -152,16 +152,16 @@ var nowCore = {
   },
 
   constructRemoteFunction: function(client, fqn){
-    
+
     nowUtil.debug("constructRemoteFunction", fqn);
-      
+
     var remoteFn = function(){
       var callId = fqn+ "_"+ nowUtil.generateRandomString(10);
-      
+
       nowUtil.debug("executeRemoteFunction", fqn + ", " + callId);
 
       var theArgs = Array.prototype.slice.call(arguments);
-      
+
       for(var i in theArgs){
         if(typeof theArgs[i] === 'function' && nowUtil.hasProperty(theArgs, i)){
           var closureId = "closure" + "_" + theArgs[i].name + "_" + nowUtil.generateRandomString(10);
@@ -174,9 +174,9 @@ var nowCore = {
     };
     return remoteFn;
   },
-  
+
   _events: {},
-  
+
   // Event code from socket.io
   on: function(name, fn){
     if (!(name in nowCore._events)) {
@@ -195,14 +195,14 @@ var nowCore = {
     }
     return nowCore;
   },
-  
+
   removeEvent: function(name, fn){
     if (name in nowCore._events){
       for (var a = 0, l = nowCore._events[name].length; a < l; a++) {
         if (nowCore._events[name][a] == fn) {
           nowCore._events[name].splice(a, 1);
         }
-      }        
+      }
     }
     return nowCore;
   }
@@ -210,19 +210,19 @@ var nowCore = {
 
 var nowLib = {
 
-  nowJSReady: function(){  
+  nowJSReady: function(){
     // client initialized
     var nowOld = now;
     now = nowCore.scopes[SERVER_ID];
     var ready = nowOld.ready;
     var core = nowOld.core;
-    
+
     delete nowOld.ready;
     delete nowOld.core;
     nowUtil.initializeScope(nowOld, socket);
 
     nowUtil.addChildrenToBlacklist(nowCore.watchersBlacklist[SERVER_ID], nowOld, "now");
-    
+
     for(var key in nowOld) {
       now[key] = nowOld[key];
     }
@@ -234,8 +234,8 @@ var nowLib = {
         nowCore.emit('ready');
       }
     }
-    
-    
+
+
     setTimeout(function(){
       nowCore.watchers[SERVER_ID].processScope();
     }, 1000);
@@ -246,9 +246,9 @@ var nowLib = {
 
   NowWatcher: function(fqnRoot, scopeObj, scopeClone, variableChanged) {
     this.data = {watchedKeys: {}, hashedArrays: {}};
-    
+
     var badNames = {'now.ready': true, 'now.core': true };
-    
+
     this.traverseObject = function(path, obj, arrayBlacklist, objClone) {
       // Prevent new array items from being double counted
       for(var key in obj){
@@ -273,7 +273,7 @@ var nowLib = {
             }
             this.data.watchedKeys[fqn] = true;
           }
-          
+
           if(obj[key] && typeof obj[key] === 'object') {
             if(nowUtil.isArray(obj[key])) {
               if(nowUtil.hasProperty(this.data.hashedArrays, fqn)){
@@ -287,10 +287,10 @@ var nowLib = {
                       arrayBlacklist[fqn+"."+i] = true;
                       this.variableChanged(i, fqn+"."+i, this.data.hashedArrays[fqn][i], diff[i]);
                     }
-                  }  
+                  }
                 }
               }
-              this.data.hashedArrays[fqn] = obj[key].slice(0); 
+              this.data.hashedArrays[fqn] = obj[key].slice(0);
             }
             if(isIE && (!nowUtil.hasProperty(objClone, key) || !(typeof objClone[key] === "object"))) {
               if(nowUtil.isArray(obj[key])) {
@@ -322,8 +322,8 @@ var nowLib = {
 
     this.variableChanged = variableChanged;
 
-     /** 
-     * Returns true if two the two arrays are identical. 
+     /**
+     * Returns true if two the two arrays are identical.
      * Returns an object of differences if keys have been added or the value at a key has changed
      * Returns false if keys have been deleted
      */
@@ -366,7 +366,7 @@ var nowLib = {
       nowCore.emit('reconnect');
     });
   }
-  
+
 };
 
 var now = {
@@ -374,8 +374,8 @@ var now = {
     if(arguments.length === 0) {
       nowCore.emit('ready');
     } else {
-      nowCore.on('ready', func); 
-    }    
+      nowCore.on('ready', func);
+    }
   },
   core: {
     on: nowCore.on,
@@ -385,18 +385,20 @@ var now = {
 };
 
 (function(){
-  var dependencies = ["/socket.io/socket.io.js"];
+  var dependencies = {
+    'io': '/socket.io/socket.io.js'
+  };
   var dependenciesLoaded = 0;
 
   var nowJSScriptLoaded = function(){
     dependenciesLoaded++;
-    if(dependenciesLoaded !== dependencies.length) {
+    if(dependenciesLoaded !== Object.keys(dependencies).length) {
       return;
     }
-    
+
     nowUtil.debug("isIE", isIE);
-   
-    socket = new io.Socket('**SERVER**', {port: **PORT**}); 
+
+    socket = new io.Socket('**SERVER**', {port: **PORT**});
     now.core.socketio = socket;
     socket.connect();
     socket.on('connect', function(){
@@ -408,10 +410,17 @@ var now = {
     });
   };
 
-  for(var i=0, ii = dependencies.length; i < ii; i++){
+  for(var ns in dependencies){
+    if (!dependencies.hasOwnProperty(ns)) {
+      continue;
+    }
+    if (window[ns]) {
+      nowJSScriptLoaded();
+      return;
+    }
     var fileref=document.createElement('script');
     fileref.setAttribute("type","text/javascript");
-    fileref.setAttribute("src", "http://**SERVER**:**PORT**"+dependencies[i]);
+    fileref.setAttribute("src", "http://**SERVER**:**PORT**"+dependencies[ns]);
     fileref.onload = nowJSScriptLoaded;
     if(isIE) {
       fileref.onreadystatechange = function () {
@@ -420,6 +429,6 @@ var now = {
         }
       };
     }
-    document.getElementsByTagName("head")[0].appendChild(fileref);  
+    document.getElementsByTagName("head")[0].appendChild(fileref);
   }
 }());


### PR DESCRIPTION
Right now, there is one http request for now.js - which in turn makes one http request for each dependency, there is only one dependency, but that makes 2 http requests, and they are not served minified.

It would be more flexible if the now.js file served to clients was minified, and was self sufficient, this would allow users to include this file into their own build process such that http requests are reduced to a minimum.

So.. with this patch you can now do this:

```
 <script src="/socket.io/socket.io.js"></script>
 <script src="/nowjs/now.js"></script>
```

Or, more importantly, this:

```
 <script src="socket-plus-node-plus-myapp.min.js"></script>
```
