### PR TITLE
use relative paths for now in the examples.

### DIFF
--- a/examples/express_example/app.js
+++ b/examples/express_example/app.js
@@ -29,7 +29,7 @@ console.log("Express server listening on port %d", app.address().port);
 
 // NowJS component
 
-var everyone = require("now").initialize(app);
+var everyone = require("../../").initialize(app);
 
 
 everyone.connected(function(){

--- a/examples/helloworld_example/helloworld_server.js
+++ b/examples/helloworld_example/helloworld_server.js
@@ -1,13 +1,13 @@
 var fs = require('fs');
 var server = require('http').createServer(function(req, response){
   fs.readFile(__dirname+'/helloworld.html', function(err, data){
-    response.writeHead(200, {'Content-Type':'text/html'}); 
-    response.write(data);  
+    response.writeHead(200, {'Content-Type':'text/html'});
+    response.write(data);
     response.end();
   });
 });
 server.listen(8080);
-var nowjs = require("now");
+var nowjs = require("../../");
 var everyone = nowjs.initialize(server);
 
 everyone.on("connect", function(){

--- a/examples/multiroomchat_example/multiroomchat_server.js
+++ b/examples/multiroomchat_example/multiroomchat_server.js
@@ -1,15 +1,15 @@
 ﻿var fs = require('fs');
 var server = require('http').createServer(function(req, response){
   fs.readFile(__dirname+'/multiroomchat.html', function(err, data){
-    response.writeHead(200, {'Content-Type':'text/html'}); 
-    response.write(data);  
+    response.writeHead(200, {'Content-Type':'text/html'});
+    response.write(data);
     response.end();
   });
 });
 server.listen(8080);
 
 
-var nowjs = require("now");
+var nowjs = require("../../");
 var everyone = nowjs.initialize(server);
 
 


### PR DESCRIPTION
using require("now") assumes users have installed now via npm -g. that
may not be the case, and if you checkout from github this will mean
the examples are not using the rest of the git checked-out code
