### PR TITLE
allow everyone.exclude(this.user.clientId).now...

### DIFF
--- a/lib/group.js
+++ b/lib/group.js
@@ -90,9 +90,15 @@ exports.initialize = function (now) {
   Group.prototype.exclude = function (clientIds) {
     var user = nowUtil.clone(this);
     user.excludes = nowUtil.clone(this.excludes);
-    for (var i=0; i<clientIds.length; i++) {
-      user.excludes[clientIds[i]] = true;
+
+    if (typeof clientIds === 'string') {
+        user.excludes[clientIds] = true;
+    } else {
+        for (var i=0; i<clientIds.length; i++) {
+          user.excludes[clientIds[i]] = true;
+        }
     }
+
     user.now = Proxy.wrap(user);
     return user;
   };


### PR DESCRIPTION
After misreading the example posted by steve here https://github.com/Flotype/now/pull/80#issuecomment-1448994

A minor change to allow excluding a single client. If this isn't appropriate, it would be IMO a good idea to check the type of clientIds and raise an error if it's not an object.
