### PR TITLE
replased host and port options with ioUri and scriptSource

### DIFF
--- a/doc/public/user_manual.md
+++ b/doc/public/user_manual.md
@@ -207,14 +207,17 @@ available options and their defaults:
     {
       "clientWrite" : true,   // Enable syncing of changes to variables that originate from the client (browser)
       "autoHost" : true,      // This flag enables NowJS to serve the client-side libraries using the provided httpServer
-      "host" : undefined,     // Overrides the autodetected host information when autoHost is enabled. You may need to set this if the server behind a reverse proxy or other complex network setup.
-      "port" : undefined,     // Overrides the autodetected port information when autoHost is enabled
-
       "socketio" : {},        // This is the options object passed into io.listen(port, options)
       "closureTimeout : 30000 // This specifies how long before references to callbacks expire.
-      "client : {},           // This specifies which options are available by default in the client-side library.
+
+      // Options applicable when autoHost is enabled
+      "ioUri" : "",           // URI used by the client to connect to the server.  You may need to set this if the server behind a reverse proxy or other complex network setup.
+      "scriptSource" : "",    // Base URI for client-side dependencies.  The default behavior is to use relative URI.
+      "client" : {},          // This specifies which options are available by default in the client-side library.
       "scope" : "window"      // A string representing the default scope in which the now namespace will be established.
                               // Do note that the object that this points to should already exist by the time now.js is loaded.
+
+
     }
 
 If the options object is incomplete, the default values will be used

--- a/lib/client/now.js
+++ b/lib/client/now.js
@@ -5,7 +5,8 @@
   var nowReady = false;
   var readied = 0;
   var lastTimeout;
-  var uri = 'http://**SERVER**:**PORT**';
+  var ioUri = '**IO_URI**';
+  var scriptSource = '**SCRIPT_SOURCE**';
 
   var fqnMap = {
     data: {},
@@ -434,7 +435,7 @@
     if (dependenciesLoaded !== dependencies.length) {
       return;
     }
-    socket = io.connect(uri+'/', now.core.options.socketio || {});
+    socket = io.connect(ioUri, now.core.options.socketio || {});
     now.core.socketio = socket;
     socket.on('connect', function () {
       now.core.clientId = socket.socket.sessionid;
@@ -478,7 +479,7 @@
     }
     var fileref=document.createElement('script');
     fileref.setAttribute('type','text/javascript');
-    fileref.setAttribute('src', uri+dependencies[i]['path']);
+    fileref.setAttribute('src', scriptSource + dependencies[i]['path']);
     fileref.onload = scriptLoaded;
     if (isIE) {
       fileref.onreadystatechange = function () {

--- a/lib/fileServer.js
+++ b/lib/fileServer.js
@@ -65,13 +65,11 @@ function serveFile(filename, request, response, options) {
         response.write(nowFileCache[request.headers.host].now);
         response.end();
       } else {
-        // Determine hostname / port if not given in options
-        var host = request.headers.host.split(':');
-        var hostServer = options['host'] || host[0];
-        var hostPort =  options['port'] || host[1] || '80';
+        var ioUri = options['ioUri'] || '';
+        var scriptSource = options['scriptSource'] || '';
 
         // Call generate client libs, which takes the desired host/port and executes callback with two parts of now.js as parameters
-        generateClientLibs(hostServer, hostPort, function (nowText, utilText) {
+        generateClientLibs(ioUri, scriptSource, function (nowText, utilText) {
 
           // Write to client
           response.writeHead(200, {'Content-Type': 'text/javascript'});
@@ -97,11 +95,11 @@ function serveFile(filename, request, response, options) {
 }
 
 // Takes host and port and call callback with now.js and nowUtil.js as parameters
-function generateClientLibs(hostServer, hostPort, callback) {
+function generateClientLibs(ioUri, scriptSource, callback) {
   fs.readFile(__dirname + '/client/now.js', function (err, data) {
     var nowText = data.toString();
-    nowText = nowText.replace('**SERVER**', hostServer);
-    nowText = nowText.replace('**PORT**', hostPort);
+    nowText = nowText.replace('**IO_URI**', ioUri);
+    nowText = nowText.replace('**SCRIPT_SOURCE**', scriptSource);
     nowText = nowText.replace('**OPTIONS**', options.client);
     nowText = nowText.replace('**SCOPE**', options.scope);
     var utilText = '';


### PR DESCRIPTION
The motivation for this patch is to auto-host now.js on an https only server, but hopefully it makes things a little more flexible too.

Currently, nowjs.initialize() takes 'host' and 'port' options, which stuffs into the client-side script, and uses them to (1) construct an absolute URI to load the socket.io client script, and (2) to initialize the io.Socket object.  This has a couple of limitations: the URI for the script is hard-coded as http (not -s), there's no way to pass the "secure" flag to socket.io, and there's no way to specify a different host for the socket.io script.  (For that last one, I admit I'm not sure why someone might auto-host now.js, but not socket.io, but hey.)

With 0.7, socket.io is initialized with a URI, and now.js currently just concatenates the server and port to create this URI.  With this patch, the user specifies the URI ("ioUri" in the options object), allowing it to be https.  This replaces the 'host' and 'port' options.  The default case, auto-hosted now.js and socket.io, with no URI specified, "just works" for http (still) and https (new!).

I've also created another option ("scriptSource"), so that one can specify a base URI for socket.io, and any other client-side dependencies, separately.
