### PR TITLE
Fix for now.js crashing when the object prototype has been extended

### DIFF
--- a/lib/fileServer.js
+++ b/lib/fileServer.js
@@ -34,13 +34,17 @@ handleResponse = function (request, response) {
     } else {
       // Make sure default listeners are still handled
       for (i in defaultListeners) {
-        defaultListeners[i].call(server, request, response);
+        if ( defaultListeners.hasOwnProperty(i) ) {
+          defaultListeners[i].call(server, request, response);
+        }
       }
     }
   } else {
     for (i in defaultListeners) {
       // Make sure default listeners are still handled
-      defaultListeners[i].call(server, request, response);
+      if ( defaultListeners.hasOwnProperty(i) ) {
+        defaultListeners[i].call(server, request, response);
+      }
     }
   }
 };


### PR DESCRIPTION
As the title says. Can this be pulled asap, as it is preventing one of my projects from being worked on. I know that object prototypes should not be extended, however there are always exceptions.
