### PR TITLE
Set options when starting socket.io server

### DIFF
--- a/lib/now.js
+++ b/lib/now.js
@@ -153,10 +153,7 @@ Now.prototype.initialize = function (server, options) {
   var self = this;
 
   fileServer.wrapServer(server, this.options);
-  this.server = io.listen(server);
-  for (var i in this.options.socketio) {
-    this.server.set(i, this.options.socketio[i]);
-  }
+  this.server = io.listen(server, this.options.socketio);
 
   // Need this to be separate from clientsMap.
   this.server.sockets.on('connection', function (socket) {


### PR DESCRIPTION
This fixes a bug that occurred when using a custom logger.
socket.io would always send "socket.io started" trough the default logger since options was not set until after the server is started.
