### PR TITLE
Add support for configuring the client-side socket.io's path (better reverse-proxy support)

### DIFF
--- a/doc/public/user_manual.md
+++ b/doc/public/user_manual.md
@@ -217,6 +217,10 @@ available options and their defaults:
                               // Do note that the object that this points to should already exist by the time now.js is loaded.
     }
 
+If the `client.socketio.resource` option is set it will also be used 
+for the path of the socket.io.js file. This option can be useful in 
+the case of a reverse proxy setup.
+
 If the options object is incomplete, the default values will be used
 in place of any missing options.
 

--- a/lib/client/now.js
+++ b/lib/client/now.js
@@ -6,6 +6,8 @@
       return nowObjects[uri];
     }
     options = options || {};
+    options.socketio = options.socketio || {};
+    options.socketio.resource = options.socketio.resource || "socket.io";
 
     var socket;
     var closures = {};
@@ -535,7 +537,7 @@
     };
 
     var dependencies = [
-      { key: 'io', path: '/socket.io/socket.io.js'}
+      { key: 'io', path: '/' + now.core.options.socketio.resource + '/socket.io.js'}
     ];
     var dependenciesLoaded = 0;
 


### PR DESCRIPTION
Using the `client.socketio.resource` option to set the path for socket.io.js instead of using the hardcoded default value of `/socket.io/socket.io.js`.
 `client.socketio.resource` defaults to `socket.io`.
