### PR TITLE
Get rid of returning values as callback argument in really synchronous functions

### DIFF
--- a/lib/group.js
+++ b/lib/group.js
@@ -50,15 +50,14 @@ exports.initialize = function (nowjs) {
    * @description Used to find the cardinality of the group (how
    * many users it contains).
 
-   * @param {Function} callback Called with a Number corresponding to
-   * the group's user count.
+   * @return {Number} A number corresponding to the group's user count.
 
    * @example everyone.count(function (ct) {
    *   console.log(ct);
    * });
    */
-  Group.prototype.count = function (callback) {
-    callback(Object.keys(this.users).length);
+  Group.prototype.count = function () {
+    return Object.keys(this.users).length;
   };
 
   /**
@@ -69,8 +68,8 @@ exports.initialize = function (nowjs) {
    * @description Used to retrieve a list of the client IDs
    * corresponding to all users in the group.
 
-   * @param {Function} callback Called with an Array of Strings
-   * corresponding to the client IDs of all users in the group.
+   * @return {Array} An Array of Strings corresponding to the client IDs of all
+   * users in the group.
 
    * @example everyone.getUsers(function (users) {
    *   for (var i = 0; i < users.length; i++) console.log(users[i]);
@@ -78,8 +77,8 @@ exports.initialize = function (nowjs) {
 
    * @see nowjs#getClient
    */
-  Group.prototype.getUsers = function (callback) {
-    callback(Object.keys(this.users));
+  Group.prototype.getUsers = function () {
+    return Object.keys(this.users);
   };
 
   /**
@@ -267,8 +266,7 @@ exports.initialize = function (nowjs) {
    * @param {String} clientId The client ID associated with the target
    * user.
 
-   * @param {Function} callback Called with a Boolean indicating the
-   * user's membership in the group.
+   * @return {Boolean} indicating the user's membership in the group.
 
    * @example group.hasClient('1234567890', function (bool) {
    *   if (bool) {
@@ -276,8 +274,8 @@ exports.initialize = function (nowjs) {
    *   }
    * });
    */
-  Group.prototype.hasClient = function (clientId, callback) {
-    callback(this.users[clientId] !== undefined);
+  Group.prototype.hasClient = function (clientId) {
+    return this.users[clientId] !== undefined;
   };
 
   /**

--- a/lib/now.js
+++ b/lib/now.js
@@ -70,8 +70,7 @@ Now.prototype.getClient = function (id, callback) {
  * array) of all groups that have been created and passes it in to the
  * supplied callback.
 
- * @param {Function} callback Takes one argument, an array of all
- * groups that have been created.
+ * @return {Array} an array of all groups that have been created.
 
  * @example nowjs.on('connect', function () {
  *   var self = this;
@@ -80,8 +79,8 @@ Now.prototype.getClient = function (id, callback) {
  *   });
  * });
  */
-Now.prototype.getGroups = function (callback) {
-  callback(Object.keys(this.groups));
+Now.prototype.getGroups = function () {
+  return Object.keys(this.groups);
 };
 
 /**
@@ -183,9 +182,8 @@ Now.prototype.initialize = function (server, options) {
 };
 
 Now.prototype.addSupportServer = function(host, port){
-  var server = new this.Support(host, port);
-  return server;
-}
+  return new this.Support(host, port);
+};
 
 exports.Now = Now;
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -158,8 +158,8 @@ exports.initialize = function (nowjs) {
    * @description Used to retrieve a list of the group names
    * corresponding to all groups the user is in.
 
-   * @param {Function} callback Called with an Array of Strings
-   * corresponding to the various group names.
+   * @return {Array} an Array of Strings corresponding to the various group
+   * names.
 
    * @example everyone.now.broadcast = function (message) {
    * var name = this.now.name;
@@ -171,8 +171,8 @@ exports.initialize = function (nowjs) {
    *   }
    * });
    */
-  User.prototype.getGroups = function (callback) {
-    callback(Object.keys(this.groups));
+  User.prototype.getGroups = function () {
+    return Object.keys(this.groups);
   };
 
   /** @private */


### PR DESCRIPTION
- Group#count
- Group#getUsers
- Group#hasClient
- User#getGroups
- nowjs#getGroups

This should make code cleaner.
